### PR TITLE
Added proxy for API servers

### DIFF
--- a/hack4change-client/src/api/hello.ts
+++ b/hack4change-client/src/api/hello.ts
@@ -1,5 +1,5 @@
 export const getHello = async () => {
-    const response = await fetch("https://localhost:8081/hello");
+    const response = await fetch("api/hello");
     
     if (!response.ok) {
         throw new Error(`Response status:  ${response.status}`)

--- a/hack4change-client/vite.config.ts
+++ b/hack4change-client/vite.config.ts
@@ -3,6 +3,16 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://localhost:8081',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+        secure: false
+      },
+    }
+  },
   plugins: [
     react({
       babel: {


### PR DESCRIPTION
Adds a proxy configuration to the Vite app server so that API requests can be accessed via the "/api" path without CORS and certificate issues.